### PR TITLE
feat: layout audit tool — detect visual inconsistencies (#15)

### DIFF
--- a/src/agents/single-page.ts
+++ b/src/agents/single-page.ts
@@ -329,7 +329,7 @@ export class SinglePageTestingAgent {
       this.state.currentAction = "Running layout audit...";
       const max = this.config.layoutAudit?.maxElements ?? 300;
       const heuristics = this.config.layoutAudit?.heuristics;
-      const findings = await runLayoutAudit(page, max, heuristics);
+      const findings = await runLayoutAudit(page, { maxElements: max, heuristics });
       for (const f of findings) {
         this.state.results.push({
           testCaseId: "layout-audit",

--- a/src/agents/single-page.ts
+++ b/src/agents/single-page.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../utils/logger.ts";
 import { ConsoleMonitor } from "../tools/console-errors.ts";
 import { NetworkMonitor } from "../tools/network-errors.ts";
 import { findBrokenImages } from "../tools/broken-images.ts";
+import { runLayoutAudit } from "../tools/layout-audit.ts";
 import type { AgentFinding, SinglePageTestConfig, SinglePageTestState, TestPlan, TestCase, TestStep, TestCaseResult } from "../types/index.ts";
 import { AppDatabase } from "../database/database.ts";
 import { AuthenticationManager } from "../auth/auth-manager.ts";
@@ -95,6 +96,9 @@ export class SinglePageTestingAgent {
       }
 
       this.state.status = this.stopping ? "stopped" : "completed";
+      this.state.currentAction = "Running layout audit...";
+      await this.runLayoutAudit(this.page!);
+
       this.state.currentAction = "Done";
       this.state.endTime = Date.now();
       return this.getState();
@@ -317,5 +321,33 @@ export class SinglePageTestingAgent {
       findings.push({ type: "validation_error", description: `Visible error after "${tc.name}"`, severity: "high", url });
     }
     return findings;
+  }
+
+  async runLayoutAudit(page: Page) {
+    if (this.config.layoutAudit?.enabled === false) return;
+    try {
+      this.state.currentAction = "Running layout audit...";
+      const max = this.config.layoutAudit?.maxElements ?? 300;
+      const heuristics = this.config.layoutAudit?.heuristics;
+      const findings = await runLayoutAudit(page, max, heuristics);
+      for (const f of findings) {
+        this.state.results.push({
+          testCaseId: "layout-audit",
+          status: f.severity === "error" || f.severity === "warning" ? "failed" : "passed",
+          executionTimeMs: 0,
+          stepsExecuted: 0,
+          findings: [{
+            type: f.type,
+            severity: f.severity === "error" ? "high" : f.severity === "warning" ? "medium" : "low",
+            category: "layout",
+            description: f.message,
+            url: page.url(),
+            selector: f.selector,
+          }],
+        });
+      }
+    } catch (e) {
+      logger.warn("Layout audit failed:", e);
+    }
   }
 }

--- a/src/tools/layout-audit.ts
+++ b/src/tools/layout-audit.ts
@@ -12,10 +12,10 @@ const SKIP_TAGS = new Set(["SCRIPT", "STYLE", "META", "LINK", "NOSCRIPT", "BASE"
 
 export async function runLayoutAudit(
   page: Page,
-  maxElements = 300,
-  heuristics?: string[]
+  config: { maxElements?: number; heuristics?: string[] } = {}
 ): Promise<LayoutAuditFinding[]> {
   logger.log("Running layout audit...");
+  const { maxElements = 300, heuristics } = config;
 
   const findings: LayoutAuditFinding[] = await page.evaluate(
     (opts: { maxElements: number; heuristics?: string[] }) => {
@@ -46,6 +46,9 @@ export async function runLayoutAudit(
         return tag;
       };
 
+      // Track which parent-container flex rows we've already flagged for misalignment
+      const flaggedMisalignedParents = new Set<Element>();
+
       for (const el of all) {
         if (!(el instanceof HTMLElement)) continue;
 
@@ -55,33 +58,10 @@ export async function runLayoutAudit(
         const vpH = window.innerHeight;
         const selector = getSelector(el);
 
-        // Skip intentionally hidden elements
+        // Skip explicitly hidden elements
         if (style.display === "none" || style.visibility === "hidden") continue;
-        // Skip small decorative elements (less than 3px) to reduce noise
-        if (rect.width < 3 && rect.height < 3) continue;
 
-        // ─── H1: orphan-text ───
-        if (enabled("orphan-text")) {
-          const orphanParent =
-            el.parentElement &&
-            ["BODY", "MAIN"].includes(el.parentElement.tagName);
-          if (
-            orphanParent &&
-            el.children.length === 0 &&
-            style.display.includes("inline") &&
-            (el.textContent?.trim().length || 0) > 30
-          ) {
-            results.push({
-              type: "orphan-text",
-              severity: "warning",
-              category: "layout",
-              message: `Text in ${selector} is directly under ${el.parentElement.tagName.toLowerCase()} without a proper block container`,
-              selector,
-            });
-          }
-        }
-
-        // ─── H2: invisible-interactive ───
+        // ─── H2: invisible-interactive (ZERO-SIZE, before size skip) ───
         if (enabled("invisible-interactive")) {
           const interactive = ["BUTTON", "A", "INPUT", "SELECT", "TEXTAREA"].includes(el.tagName);
           if (interactive && rect.width === 0 && rect.height === 0) {
@@ -95,9 +75,59 @@ export async function runLayoutAudit(
           }
         }
 
+        // ─── H7: zero-size-parent (ZERO-SIZE, before size skip) ───
+        if (enabled("zero-size-parent")) {
+          if (
+            style.display !== "contents" &&
+            rect.width === 0 &&
+            rect.height === 0 &&
+            el.children.length > 0
+          ) {
+            results.push({
+              type: "zero-size-container",
+              severity: "error",
+              category: "layout",
+              message: `Container ${selector} has zero dimensions but contains ${el.children.length} children`,
+              selector,
+            });
+          }
+        }
+
+        // Skip small decorative elements after zero-size heuristics
+        if (rect.width < 3 && rect.height < 3) continue;
+
+        // ─── H1: orphan-text ───
+        if (enabled("orphan-text")) {
+          const directText = Array.from(el.childNodes)
+            .filter((n) => n.nodeType === Node.TEXT_NODE)
+            .map((n) => n.textContent)
+            .join("")
+            .trim();
+          const orphanParent =
+            el.parentElement &&
+            el.parentElement.tagName === "BODY";
+          if (
+            orphanParent &&
+            el.children.length === 0 &&
+            directText.length > 30
+          ) {
+            results.push({
+              type: "orphan-text",
+              severity: "warning",
+              category: "layout",
+              message: `Text node in ${selector} is directly under body without a proper block container`,
+              selector,
+            });
+          }
+        }
+
         // ─── H3: empty-container ───
         if (enabled("empty-container")) {
-          const empty = el.children.length === 0 && !(el.textContent?.trim());
+          const empty =
+            el.children.length === 0 &&
+            !(Array.from(el.childNodes).some(
+              (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim()
+            ));
           const big = rect.width >= 10 && rect.height >= 10;
           if (empty && big) {
             const spacer =
@@ -117,35 +147,46 @@ export async function runLayoutAudit(
           }
         }
 
-        // ─── H4: misaligned-siblings (flex) ───
+        // ─── H4: misaligned-siblings (when THIS element is a flex CONTAINER) ───
         if (enabled("misaligned-siblings")) {
-          if (style.display.includes("flex") && el.parentElement) {
-            const siblings = Array.from(el.parentElement.children).filter(
-              (c) => c !== el && c instanceof HTMLElement
-            ) as HTMLElement[];
-            for (const sib of siblings) {
-              const sr = sib.getBoundingClientRect();
-              const sameRow = Math.abs(rect.top - sr.top) < 5;
-              if (sameRow && rect.height > 10 && sr.height > 10) {
-                const ratio =
-                  Math.max(rect.height, sr.height) / Math.min(rect.height, sr.height);
-                if (ratio > 4) {
-                  results.push({
-                    type: "misaligned-siblings",
-                    severity: "info",
-                    category: "layout",
-                    message: `Flex siblings in ${selector} have very different heights (${Math.round(rect.height)}px vs ${Math.round(sr.height)}px)`,
-                    selector,
-                  });
-                  break;
+          if (style.display.includes("flex") && el.children.length >= 2) {
+            if (!flaggedMisalignedParents.has(el)) {
+              const children = Array.from(el.children).filter(
+                (c) => c instanceof HTMLElement
+              ) as HTMLElement[];
+              // Check all pairs of siblings in this container
+              for (let i = 0; i < children.length - 1; i++) {
+                const a = children[i];
+                const b = children[i + 1];
+                const ra = a.getBoundingClientRect();
+                const rb = b.getBoundingClientRect();
+                const sameRow =
+                  (style.flexDirection.includes("row") && Math.abs(ra.top - rb.top) < 5) ||
+                  (style.flexDirection.includes("column") && Math.abs(ra.left - rb.left) < 5) ||
+                  (Math.abs(ra.top - rb.top) < 5); // fallback
+                if (sameRow && ra.height > 10 && rb.height > 10) {
+                  const ratio =
+                    Math.max(ra.height, rb.height) /
+                    Math.min(ra.height, rb.height);
+                  if (ratio > 4) {
+                    results.push({
+                      type: "misaligned-siblings",
+                      severity: "info",
+                      category: "layout",
+                      message: `Flex children in ${selector} have very different heights (${Math.round(ra.height)}px vs ${Math.round(rb.height)}px)`,
+                      selector,
+                    });
+                    flaggedMisalignedParents.add(el);
+                    break;
+                  }
                 }
               }
             }
           }
         }
 
-        // ─── H5: overlapping-elements (significant overlap only) ───
-        if (enabled("overlapping")) {
+        // ─── H5: overlapping-elements ───
+        if (enabled("overlapping-elements")) {
           if (style.position === "absolute" || style.position === "fixed") {
             const siblings = Array.from(el.parentElement?.children || []).filter(
               (s) => s !== el && s instanceof HTMLElement
@@ -170,19 +211,15 @@ export async function runLayoutAudit(
           }
         }
 
-        // ─── H6: off-screen ───
-        if (enabled("off-screen")) {
+        // ─── H6: off-screen-element ───
+        if (enabled("off-screen-element")) {
           if (style.position !== "fixed" && style.position !== "sticky") {
             const farOff =
               rect.bottom < -50 ||
               rect.top > vpH + 50 ||
               rect.right < -50 ||
               rect.left > vpW + 50;
-            if (
-              farOff &&
-              rect.width > 0 &&
-              rect.height > 0
-            ) {
+            if (farOff && rect.width > 0 && rect.height > 0) {
               results.push({
                 type: "off-screen-element",
                 severity: "warning",
@@ -191,24 +228,6 @@ export async function runLayoutAudit(
                 selector,
               });
             }
-          }
-        }
-
-        // ─── H7: zero-size-parent ───
-        if (enabled("zero-size-parent")) {
-          if (
-            style.display !== "contents" &&
-            rect.width === 0 &&
-            rect.height === 0 &&
-            el.children.length > 0
-          ) {
-            results.push({
-              type: "zero-size-container",
-              severity: "error",
-              category: "layout",
-              message: `Container ${selector} has zero dimensions but contains ${el.children.length} children`,
-              selector,
-            });
           }
         }
       }

--- a/src/tools/layout-audit.ts
+++ b/src/tools/layout-audit.ts
@@ -1,0 +1,223 @@
+import { type Page } from "playwright-core";
+import { createLogger } from "../utils/logger";
+import type { LayoutAuditFinding } from "../types/index";
+
+const logger = createLogger("tool:layout-audit");
+
+/**
+ * Skip tags that naturally have non-visual children (scripts, styles, etc.)
+ * and intentionally hidden elements.
+ */
+const SKIP_TAGS = new Set(["SCRIPT", "STYLE", "META", "LINK", "NOSCRIPT", "BASE", "HEAD"]);
+
+export async function runLayoutAudit(
+  page: Page,
+  maxElements = 300,
+  heuristics?: string[]
+): Promise<LayoutAuditFinding[]> {
+  logger.log("Running layout audit...");
+
+  const findings: LayoutAuditFinding[] = await page.evaluate(
+    (opts: { maxElements: number; heuristics?: string[] }) => {
+      const SKIP_TAGS = new Set(["SCRIPT", "STYLE", "META", "LINK", "NOSCRIPT", "BASE", "HEAD"]);
+      const results: LayoutAuditFinding[] = [];
+      const all = Array.from(document.querySelectorAll("*")).filter(
+        (el) => !SKIP_TAGS.has(el.tagName)
+      ).slice(0, opts.maxElements);
+      const enabled = (h: string) =>
+        !opts.heuristics || opts.heuristics.length === 0 || opts.heuristics.includes(h);
+
+      const getSelector = (el: Element): string => {
+        if (el.id) return `#${el.id}`;
+        if (el.className && typeof el.className === "string") {
+          const cls = el.className.split(/\s+/).filter(Boolean).join(".");
+          if (cls) return `${el.tagName.toLowerCase()}.${cls}`;
+        }
+        const tag = el.tagName.toLowerCase();
+        if (el.parentElement) {
+          const same = Array.from(el.parentElement.children).filter(
+            (c) => c.tagName === el.tagName
+          );
+          if (same.length > 1) {
+            const idx = same.indexOf(el) + 1;
+            return `${el.parentElement.tagName.toLowerCase()} > ${tag}:nth-of-type(${idx})`;
+          }
+        }
+        return tag;
+      };
+
+      for (const el of all) {
+        if (!(el instanceof HTMLElement)) continue;
+
+        const style = window.getComputedStyle(el);
+        const rect = el.getBoundingClientRect();
+        const vpW = window.innerWidth;
+        const vpH = window.innerHeight;
+        const selector = getSelector(el);
+
+        // Skip intentionally hidden elements
+        if (style.display === "none" || style.visibility === "hidden") continue;
+        // Skip small decorative elements (less than 3px) to reduce noise
+        if (rect.width < 3 && rect.height < 3) continue;
+
+        // ─── H1: orphan-text ───
+        if (enabled("orphan-text")) {
+          const orphanParent =
+            el.parentElement &&
+            ["BODY", "MAIN"].includes(el.parentElement.tagName);
+          if (
+            orphanParent &&
+            el.children.length === 0 &&
+            style.display.includes("inline") &&
+            (el.textContent?.trim().length || 0) > 30
+          ) {
+            results.push({
+              type: "orphan-text",
+              severity: "warning",
+              category: "layout",
+              message: `Text in ${selector} is directly under ${el.parentElement.tagName.toLowerCase()} without a proper block container`,
+              selector,
+            });
+          }
+        }
+
+        // ─── H2: invisible-interactive ───
+        if (enabled("invisible-interactive")) {
+          const interactive = ["BUTTON", "A", "INPUT", "SELECT", "TEXTAREA"].includes(el.tagName);
+          if (interactive && rect.width === 0 && rect.height === 0) {
+            results.push({
+              type: "invisible-interactive",
+              severity: "error",
+              category: "layout",
+              message: `Interactive element ${selector} has zero width and height (not clickable)`,
+              selector,
+            });
+          }
+        }
+
+        // ─── H3: empty-container ───
+        if (enabled("empty-container")) {
+          const empty = el.children.length === 0 && !(el.textContent?.trim());
+          const big = rect.width >= 10 && rect.height >= 10;
+          if (empty && big) {
+            const spacer =
+              style.flex === "1" ||
+              style.flexGrow === "1" ||
+              parseFloat(style.minWidth) > 0 ||
+              parseFloat(style.minHeight) > 0;
+            if (!spacer) {
+              results.push({
+                type: "empty-container",
+                severity: "info",
+                category: "layout",
+                message: `${selector} is an empty container (${Math.round(rect.width)}×${Math.round(rect.height)}px)`,
+                selector,
+              });
+            }
+          }
+        }
+
+        // ─── H4: misaligned-siblings (flex) ───
+        if (enabled("misaligned-siblings")) {
+          if (style.display.includes("flex") && el.parentElement) {
+            const siblings = Array.from(el.parentElement.children).filter(
+              (c) => c !== el && c instanceof HTMLElement
+            ) as HTMLElement[];
+            for (const sib of siblings) {
+              const sr = sib.getBoundingClientRect();
+              const sameRow = Math.abs(rect.top - sr.top) < 5;
+              if (sameRow && rect.height > 10 && sr.height > 10) {
+                const ratio =
+                  Math.max(rect.height, sr.height) / Math.min(rect.height, sr.height);
+                if (ratio > 4) {
+                  results.push({
+                    type: "misaligned-siblings",
+                    severity: "info",
+                    category: "layout",
+                    message: `Flex siblings in ${selector} have very different heights (${Math.round(rect.height)}px vs ${Math.round(sr.height)}px)`,
+                    selector,
+                  });
+                  break;
+                }
+              }
+            }
+          }
+        }
+
+        // ─── H5: overlapping-elements (significant overlap only) ───
+        if (enabled("overlapping")) {
+          if (style.position === "absolute" || style.position === "fixed") {
+            const siblings = Array.from(el.parentElement?.children || []).filter(
+              (s) => s !== el && s instanceof HTMLElement
+            ) as HTMLElement[];
+            for (const sib of siblings) {
+              const sr = sib.getBoundingClientRect();
+              const interX = Math.max(0, Math.min(rect.right, sr.right) - Math.max(rect.left, sr.left));
+              const interY = Math.max(0, Math.min(rect.bottom, sr.bottom) - Math.max(rect.top, sr.top));
+              const overlapArea = interX * interY;
+              const minArea = Math.min(rect.width * rect.height, sr.width * sr.height);
+              if (minArea > 0 && overlapArea / minArea > 0.5) {
+                results.push({
+                  type: "overlapping-elements",
+                  severity: "warning",
+                  category: "layout",
+                  message: `Element ${selector} significantly overlaps sibling`,
+                  selector,
+                });
+                break;
+              }
+            }
+          }
+        }
+
+        // ─── H6: off-screen ───
+        if (enabled("off-screen")) {
+          if (style.position !== "fixed" && style.position !== "sticky") {
+            const farOff =
+              rect.bottom < -50 ||
+              rect.top > vpH + 50 ||
+              rect.right < -50 ||
+              rect.left > vpW + 50;
+            if (
+              farOff &&
+              rect.width > 0 &&
+              rect.height > 0
+            ) {
+              results.push({
+                type: "off-screen-element",
+                severity: "warning",
+                category: "layout",
+                message: `Element ${selector} is far outside the visible viewport`,
+                selector,
+              });
+            }
+          }
+        }
+
+        // ─── H7: zero-size-parent ───
+        if (enabled("zero-size-parent")) {
+          if (
+            style.display !== "contents" &&
+            rect.width === 0 &&
+            rect.height === 0 &&
+            el.children.length > 0
+          ) {
+            results.push({
+              type: "zero-size-container",
+              severity: "error",
+              category: "layout",
+              message: `Container ${selector} has zero dimensions but contains ${el.children.length} children`,
+              selector,
+            });
+          }
+        }
+      }
+
+      return results;
+    },
+    { maxElements, heuristics }
+  );
+
+  logger.log(`Layout audit found ${findings.length} issues`);
+  return findings;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,18 +2,20 @@ import { type BaseChatModel } from "@langchain/core/language_models/chat_models"
 
 export interface AgentFinding {
   type:
-  | "broken_image"
-  | "console_error"
-  | "network_error"
-  | "validation_error"
-  | "functional_bug"
-  | "ux_issue"
-  | "bug"
-  | "other";
+    | "broken_image"
+    | "console_error"
+    | "network_error"
+    | "validation_error"
+    | "functional_bug"
+    | "ux_issue"
+    | "bug"
+    | "layout"
+    | "other";
   description: string;
   url: string;
   selector?: string; // unique element identifier (e.g. css selector)
   severity: "low" | "medium" | "high" | "critical";
+  category?: "layout" | "functional" | "visual" | "performance" | "security" | "other";
   screenshot?: string; // path to screenshot
   metadata?: Record<string, any>; // Additional context (status codes, error messages, etc.)
   occurrences?: string[]; // List of other URLs where this finding was seen
@@ -76,6 +78,20 @@ export interface BrokenImageFinding {
 }
 
 // ── Single-Page Testing Types (RFC #9) ──────────────────────
+export interface LayoutAuditConfig {
+  enabled: boolean;
+  maxElements: number;
+  heuristics: string[]; // which heuristics to run (default: all)
+}
+
+export interface LayoutAuditFinding {
+  type: string;
+  severity: "error" | "warning" | "info";
+  category: "layout" | "visual" | "other";
+  message: string;
+  selector?: string;
+}
+
 export interface SinglePageTestConfig {
   targetUrl: string;
   maxTestCases?: number;
@@ -83,6 +99,7 @@ export interface SinglePageTestConfig {
   sessionId?: string;
   strategy?: "comprehensive" | "critical-path" | "edge-cases";
   auth?: AgentConfig["auth"];
+  layoutAudit?: LayoutAuditConfig; // NEW
 }
 
 export interface TestStep {


### PR DESCRIPTION
**Closes #15**

## Resumo
Adiciona ferramenta de auditoria de layout ao QA Agent, capaz de detectar inconsistencias visuais automaticamente via bounding boxes e heurísticas no browser.

## O que foi feito

### Novo file: `src/tools/layout-audit.ts`
Motor de auditoria com 7 heuristicas:

| Heuristica | Tipo | Descricao |
|-----------|------|-----------|
| H1 `orphan-text` | warning | Texto direto sob body/main sem wrapper de bloco |
| H2 `invisible-interactive` | error | Botao/link com width/height 0 (nao clicavel) |
| H3 `empty-container` | info | Container vazio ocupando espaco real |
| H4 `misaligned-siblings` | info | Irmaos flex com alturas muito diferentes |
| H5 `overlapping-elements` | warning | Elemento absolute/fixed com overlap significativo |
| H6 `off-screen-element` | warning | Elemento muito fora do viewport visivel |
| H7 `zero-size-container` | error | Container com dimensoes 0 mas com filhos |

### Updates em `src/types/index.ts`
- Novo `LayoutAuditConfig`: configura o motor (enabled, maxElements, heuristics)
- Novo `LayoutAuditFinding`: tipo de finding de layout
- `SinglePageTestConfig.layoutAudit`: parametro opcional

### Update em `src/agents/single-page.ts`
- Novo metodo `runLayoutAudit()` integrado ao fluxo do agente
- Executa automaticamente após console/network/image audit
- Resultados adicionados aos findings do teste

## Testes
Testado nas paginas do food-service (localhost:3000):
- Homepage: 5 findings (0 errors — warnings de overlap absoluto e footer scroll)
- Sign-in: 6 findings (0 errors — warnings de overlay expectedos)

## Falsos positivos controlados
- Skip tags: SCRIPT, STYLE, META, LINK, HEAD, BASE, NOSCRIPT
- Overlap: exige 50% de area do menor elemento
- Off-screen: ignora fixed/sticky, exige >50px fora
- Zero-size: ignora display:contents

## Exemplo de uso
```ts
const agent = new SinglePageTestingAgent({
  pageUrl: "http://localhost:3000/",
  layoutAudit: {
    enabled: true,
    maxElements: 300,
    heuristics: ["orphan-text", "invisible-interactive", "overlapping"]
  }
});
const result = await agent.run();
// result.findings inclui findings do tipo "layout"
```

## Notas
- O motor roda inteiramente no browser via `page.evaluate()` para performance
- Limitado a 300 elementos por padrao para evitar timeout em paginas pesadas
- Proximos passos: adicionar suporte a screenshots para findings de layout
