### PR TITLE
feat(mcp): add visual regression and layout audit to MCP tools

### DIFF
--- a/src/mcp/tools/definitions.ts
+++ b/src/mcp/tools/definitions.ts
@@ -89,6 +89,118 @@ export const TOOL_DEFINITIONS = [
           description: "App identifier to store/retrieve saved credentials (default: 'mcp-test')",
           default: "mcp-test",
         },
+        visualRegression: {
+          type: "object" as const,
+          description: "Visual regression testing configuration",
+          properties: {
+            enabled: {
+              type: "boolean" as const,
+              description: "Enable visual regression testing",
+              default: false,
+            },
+            baselineDir: {
+              type: "string" as const,
+              description: "Directory to store baseline screenshots",
+              default: "./test-results/baselines",
+            },
+            currentDir: {
+              type: "string" as const,
+              description: "Directory to store current test screenshots",
+              default: "./test-results/current",
+            },
+            diffDir: {
+              type: "string" as const,
+              description: "Directory to store diff images",
+              default: "./test-results/diffs",
+            },
+            viewports: {
+              type: "array" as const,
+              description: "Viewports to test",
+              default: [
+                { width: 1920, height: 1080, name: "desktop" },
+                { width: 768, height: 1024, name: "tablet" },
+                { width: 375, height: 667, name: "mobile" },
+              ],
+              items: {
+                type: "object" as const,
+                properties: {
+                  width: { type: "number" as const },
+                  height: { type: "number" as const },
+                  name: { type: "string" as const },
+                },
+                required: ["width", "height", "name"],
+              },
+            },
+            threshold: {
+              type: "number" as const,
+              description: "Pixel difference threshold (0-1, lower = stricter)",
+              default: 0.1,
+            },
+            pixelmatchThreshold: {
+              type: "number" as const,
+              description: "Pixelmatch sensitivity (0-1, lower = stricter)",
+              default: 0.1,
+            },
+            captureFullPage: {
+              type: "boolean" as const,
+              description: "Capture full page screenshots",
+              default: true,
+            },
+            generateDiffImages: {
+              type: "boolean" as const,
+              description: "Generate diff images showing visual changes",
+              default: true,
+            },
+          },
+        },
+        layoutAudit: {
+          type: "object" as const,
+          description: "Layout audit configuration",
+          properties: {
+            enabled: {
+              type: "boolean" as const,
+              description: "Enable layout audit",
+              default: false,
+            },
+            maxElements: {
+              type: "number" as const,
+              description: "Maximum elements to audit (default: 300)",
+              default: 300,
+            },
+            heuristics: {
+              type: "array" as const,
+              description: "Specific heuristics to run (default: all)",
+              items: { type: "string" as const },
+            },
+            screenshots: {
+              type: "object" as const,
+              description: "Screenshot configuration for layout findings",
+              properties: {
+                enabled: {
+                  type: "boolean" as const,
+                  description: "Enable screenshots for layout findings",
+                  default: true,
+                },
+                outputDir: {
+                  type: "string" as const,
+                  description: "Output directory for screenshots",
+                  default: "./test-results/layout-audit",
+                },
+                highlightElements: {
+                  type: "boolean" as const,
+                  description: "Highlight elements in screenshots",
+                  default: true,
+                },
+                type: {
+                  type: "string" as const,
+                  enum: ["png", "jpeg"],
+                  description: "Screenshot format",
+                  default: "png",
+                },
+              },
+            },
+          },
+        },
       },
       required: ["targetUrl"] as const,
     },

--- a/src/mcp/tools/single-page.ts
+++ b/src/mcp/tools/single-page.ts
@@ -2,6 +2,10 @@ import { SinglePageTestingAgent } from "../../agents/single-page";
 import { AppDatabase } from "../../database/database";
 import { activeTests } from "../server";
 import { createLogger } from "../../utils/logger";
+import type { 
+  VisualRegressionConfig, 
+  LayoutAuditConfig 
+} from "../../types/index";
 
 const logger = createLogger("mcp:single-page");
 
@@ -14,6 +18,28 @@ export async function handleRunSinglePageTest(args: {
   authEmail?: string;
   authPassword?: string;
   authAppIdentifier?: string;
+  visualRegression?: {
+    enabled?: boolean;
+    baselineDir?: string;
+    currentDir?: string;
+    diffDir?: string;
+    viewports?: Array<{ width: number; height: number; name: string }>;
+    threshold?: number;
+    pixelmatchThreshold?: number;
+    captureFullPage?: boolean;
+    generateDiffImages?: boolean;
+  };
+  layoutAudit?: {
+    enabled?: boolean;
+    maxElements?: number;
+    heuristics?: string[];
+    screenshots?: {
+      enabled?: boolean;
+      outputDir?: string;
+      highlightElements?: boolean;
+      type?: "png" | "jpeg";
+    };
+  };
 }) {
   const sessionId = args.sessionId || `sp-${Date.now()}`;
 
@@ -34,6 +60,43 @@ export async function handleRunSinglePageTest(args: {
     state: initialState,
     abortController: { abort: () => {} },
   });
+
+  // Build optional configs
+  let visualRegressionConfig: VisualRegressionConfig | undefined;
+  if (args.visualRegression?.enabled) {
+    visualRegressionConfig = {
+      enabled: true,
+      baselineDir: args.visualRegression.baselineDir ?? "./test-results/baselines",
+      currentDir: args.visualRegression.currentDir ?? "./test-results/current",
+      diffDir: args.visualRegression.diffDir ?? "./test-results/diffs",
+      viewports: args.visualRegression.viewports ?? [
+        { width: 1920, height: 1080, name: "desktop" },
+        { width: 768, height: 1024, name: "tablet" },
+        { width: 375, height: 667, name: "mobile" },
+      ],
+      threshold: args.visualRegression.threshold ?? 0.1,
+      pixelmatchThreshold: args.visualRegression.pixelmatchThreshold ?? 0.1,
+      captureFullPage: args.visualRegression.captureFullPage ?? true,
+      generateDiffImages: args.visualRegression.generateDiffImages ?? true,
+    };
+  }
+
+  let layoutAuditConfig: LayoutAuditConfig | undefined;
+  if (args.layoutAudit?.enabled) {
+    layoutAuditConfig = {
+      enabled: true,
+      maxElements: args.layoutAudit.maxElements ?? 300,
+      heuristics: args.layoutAudit.heuristics ?? [],
+      screenshots: args.layoutAudit.screenshots?.enabled
+        ? {
+            enabled: true,
+            outputDir: args.layoutAudit.screenshots.outputDir ?? "./test-results/layout-audit",
+            highlightElements: args.layoutAudit.screenshots.highlightElements ?? true,
+            type: args.layoutAudit.screenshots.type ?? "png",
+          }
+        : undefined,
+    };
+  }
 
   // Fire-and-forget
   (async () => {
@@ -56,6 +119,8 @@ export async function handleRunSinglePageTest(args: {
                 : undefined,
             }
           : undefined,
+        visualRegression: visualRegressionConfig,
+        layoutAudit: layoutAuditConfig,
       });
 
       // Update abort handler
@@ -88,6 +153,15 @@ export async function handleRunSinglePageTest(args: {
     }
   })();
 
+  // Build response message
+  const features: string[] = [];
+  if (args.visualRegression?.enabled) {
+    features.push(`visual regression (${visualRegressionConfig?.viewports.length || 0} viewports)`);
+  }
+  if (args.layoutAudit?.enabled) {
+    features.push("layout audit");
+  }
+
   return {
     content: [
       {
@@ -96,7 +170,10 @@ export async function handleRunSinglePageTest(args: {
           sessionId,
           targetUrl: args.targetUrl,
           authConfigured: !!args.authRequired,
-          message: `Single-page test started for ${args.targetUrl}. Use get_test_status with sessionId "${sessionId}" to monitor progress.`,
+          features: features.length > 0 ? features : undefined,
+          message: features.length > 0
+            ? `Single-page test started for ${args.targetUrl} with ${features.join(" + ")}. Use get_test_status with sessionId "${sessionId}" to monitor progress.`
+            : `Single-page test started for ${args.targetUrl}. Use get_test_status with sessionId "${sessionId}" to monitor progress.`,
         }, null, 2),
       },
     ],


### PR DESCRIPTION
Implements #21

- Add visualRegression parameter to run_single_page_test tool definition
  - Support viewports (width, height, name)
  - Configurable thresholds (threshold, pixelmatchThreshold)
  - Directory paths (baselineDir, currentDir, diffDir)
  - Toggle options (captureFullPage, generateDiffImages)

- Add layoutAudit parameter to run_single_page_test tool definition
  - maxElements limit
  - heuristics array for specific checks
  - screenshot configuration (enabled, outputDir, highlightElements, type)

- Update handleRunSinglePageTest to process new parameters
  - Build VisualRegressionConfig from MCP args
  - Build LayoutAuditConfig from MCP args
  - Pass configs to SinglePageTestingAgent
  - Include enabled features in response message

- Import types from ../../types/index for type safety

MCP clients can now run visual regression and layout audit via: {
  "targetUrl": "...",
  "visualRegression": { "enabled": true, ... },
  "layoutAudit": { "enabled": true, ... }
}